### PR TITLE
prepared for ruby1.8.7

### DIFF
--- a/lib/tactful_tokenizer.rb
+++ b/lib/tactful_tokenizer.rb
@@ -117,7 +117,7 @@ module TactfulTokenizer
                 end
 
                 if w2.chop.is_alphabetic?
-                    frag.features.push "w2cap_#{w2[0].is_upper_case?}", "w2lower_#{model.lower_words[w2.downcase]}"
+                    frag.features.push "w2cap_#{w2[0].chr.is_upper_case?}", "w2lower_#{model.lower_words[w2.downcase]}"
                 end
             end
         end


### PR DESCRIPTION
Fix to avoid 'NoMethodError at /undefined method `is_upper_case?' for 68:Fixnum' with Ruby 1.8.7
